### PR TITLE
Message div zero

### DIFF
--- a/minitrice.py
+++ b/minitrice.py
@@ -7,7 +7,11 @@ def Operation(Operateur, Calcul):
         print("Division par 0")
         raise SystemExit(1)  #On sort du programme avec le code erreur 1
     else:
-        print(eval(Calcul))
+        try:
+            print(eval(Calcul))
+        except:
+            print("Erreur de syntaxe pour le calcul: \""+ ope_Calcul +"\"")
+            SystemExit(-1)
 
 def compter_operateurs(Calcul):
     # Compte le nombre total d'opérateurs dans l'expression
@@ -36,11 +40,9 @@ if __name__ == "__main__":
             for i in list_Operation:
                 if(i in ope_Calcul):
                     operatorFound = True
-                    try:
-                        Operation(i, ope_Calcul)
-                    except:
-                        print("Erreur de syntaxe pour le calcul: \""+ ope_Calcul +"\"")
-                        SystemExit(-1)
+
+                    Operation(i, ope_Calcul)
+                    
 
             if(operatorFound is False):
                 print("Erreur de syntaxe pour le calcul: \""+ ope_Calcul +"\"")

--- a/minitrice.py
+++ b/minitrice.py
@@ -3,19 +3,14 @@
 def Operation(Operateur, Calcul):
     ope1, ope2 = Calcul.split(Operateur)
     ope1, ope2 = int(ope1), int(ope2)  # Exception si le string ne peut être converti
-    if Operateur == "/" and ope2 == 0:  # Cas division par 0
-        print("Division par 0")
-        raise SystemExit(1)  #On sort du programme avec le code erreur 1
-    else:
-        try:
-            print(eval(Calcul))
-        except:
-            print("Erreur de syntaxe pour le calcul: \""+ ope_Calcul +"\"")
-            SystemExit(-1)
+
+    print(eval(Calcul))
+    
+            
 
 def compter_operateurs(Calcul):
     # Compte le nombre total d'opérateurs dans l'expression
-    return sum(Calcul.count(op) for op in ["+", "/"])
+    return sum(Calcul.count(op) for op in ["+","-","/"])
 
 #Programme principale
 if __name__ == "__main__":
@@ -40,8 +35,15 @@ if __name__ == "__main__":
             for i in list_Operation:
                 if(i in ope_Calcul):
                     operatorFound = True
-
-                    Operation(i, ope_Calcul)
+                    try:
+                        Operation(i, ope_Calcul)
+                    except ZeroDivisionError:
+                        print("Division par 0")
+                        SystemExit(1)
+                    except :
+                        print("Erreur de syntaxe pour le calcul: \""+ ope_Calcul +"\"")
+                        SystemExit(-1)
+                        
                     
 
             if(operatorFound is False):


### PR DESCRIPTION
Maintenant le message pour la division par 0 s'affiche correctement, sans le message sur la syntaxe derrière